### PR TITLE
minor bugfix to adapter-bitbang.c that does not affect operation.

### DIFF
--- a/adapter-bitbang.c
+++ b/adapter-bitbang.c
@@ -980,7 +980,7 @@ adapter_t *adapter_open_bitbang (const char *port, int baud_rate)
         buffer[0] = STK_ENTER_PROGMODE;                 // enter program mode (not needed)
         buffer[1] = CRC_EOP;
         serial_write (buffer, 2);
-        serial_read (buffer, 2);
+        n = serial_read (buffer, 2);
 
         if ((n != 2) || (buffer[0] != STK_INSYNC) || (buffer[1] != STK_OK)) {
             fprintf (stderr, "Failed to enter program mode\n");

--- a/adapter-bitbang.c
+++ b/adapter-bitbang.c
@@ -1050,10 +1050,10 @@ adapter_t *adapter_open_bitbang (const char *port, int baud_rate)
             exit (-1);
         }
         printf ("Firmware uploaded to 'ascii ICSP' adapter OK\n");
+        serial_close();
 #else
         printf ("Firmware upload to arduino/STK500 not included\n");
 #endif
-        serial_close();
         exit (0);                                       // finished performing function, exit program
     }
 


### PR DESCRIPTION
hi Serge,
    this fix does not warrant recompiling pic32prog at this time, but should be included when things are next compiled. this is also a test of how to use "Git Gui" and to see if everything is working correctly at my end. since i run winXP the software supplied by GitHub will not install on my computer (it requires win7), hence the need to use "Git Gui".

cheers,
rob   :-)
