### PR TITLE
Fix for issue #21 - Recognize "AVRISP_2" as valid response from chipK…

### DIFF
--- a/adapter-stk500v2.c
+++ b/adapter-stk500v2.c
@@ -482,7 +482,9 @@ adapter_t *adapter_open_stk500v2 (const char *port, int baud_rate)
     for (;;) {
         /* Send CMD_SIGN_ON. */
         if (send_receive (a, (unsigned char*)"\1", 1, response, 11) &&
-            memcmp (response, "\1\0\10STK500_2", 11) == 0) {
+            ((memcmp (response, "\1\0\10STK500_2", 11) == 0)
+            ||
+            (memcmp (response, "\1\0\10AVRISP_2", 11) == 0))) {
             if (debug_level > 1)
                 printf ("stk-probe: OK\n");
             break;


### PR DESCRIPTION
…IT bootloader.

Tested on Windows, and works with UNO32 chipKIT board. (UNO32 bootloader responds with "AVRISP_2")
