### PR TITLE
Use dynamic libusb on Linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ CCARCH          =
 
 # Linux
 ifeq ($(UNAME),Linux)
-    LIBS        += -Wl,-Bstatic -lusb-1.0 -Wl,-Bdynamic -lpthread -ludev
+    LIBS        += -Wl,-Bdynamic -lusb-1.0 -lpthread -ludev
     HIDLIB      = hidapi/libusb/.libs/libhidapi-libusb.a
 endif
 


### PR DESCRIPTION
Fedora uses libusbx, and doesn't come with a statically linked version.

Here's what the devel package has:

```
# rpm -ql libusbx-devel
/usr/include/libusb-1.0
/usr/include/libusb-1.0/libusb.h
/usr/lib64/libusb-1.0.so
/usr/lib64/pkgconfig/libusb-1.0.pc
```

pic32prog is not in Fedora at the moment, and while I don't know the reason, this is one roadblock.

I'm not sure that the library needs to be statically linked, so I hope this doesn't break anything.